### PR TITLE
moving zf1-xml dependency to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "diablomedia/zendframework1-navigation": "^1.0.0",
         "diablomedia/zendframework1-session": "^1.0.0",
         "diablomedia/zendframework1-translate": "^1.0.0",
-        "diablomedia/zendframework1-view": "^1.0.0",
+        "diablomedia/zendframework1-view": "^1.0.4",
         "diablomedia/zendframework1-view-helper-navigation": "^1.0.0"
     },
     "autoload": {
@@ -42,7 +42,6 @@
         }
     },
     "require-dev": {
-        "diablomedia/zendframework1-xml": "^1.0.5",
         "phpunit/phpunit": "^8.4",
         "phpstan/phpstan": "0.12.82",
         "friendsofphp/php-cs-fixer": "2.18.3",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "diablomedia/zendframework1-session": "^1.0.0",
         "diablomedia/zendframework1-translate": "^1.0.0",
         "diablomedia/zendframework1-view": "^1.0.0",
-        "diablomedia/zendframework1-view-helper-navigation": "^1.0.0",
-        "diablomedia/zendframework1-xml": "^1.0.5"
+        "diablomedia/zendframework1-view-helper-navigation": "^1.0.0"
     },
     "autoload": {
         "psr-0": {
@@ -43,6 +42,7 @@
         }
     },
     "require-dev": {
+        "diablomedia/zendframework1-xml": "^1.0.5",
         "phpunit/phpunit": "^8.4",
         "phpstan/phpstan": "0.12.82",
         "friendsofphp/php-cs-fixer": "2.18.3",


### PR DESCRIPTION
I had put the zf1-xml dependency in the composer dependencies to force a minimum version of 1.0.5 since tests failed without it. However, this library doesn't depend on that package directly, so I think it makes sense to keep it in the dev deps.